### PR TITLE
requires user to sign in before retrieving questions

### DIFF
--- a/app/src/main/java/com/example/solve/HomeFragment.kt
+++ b/app/src/main/java/com/example/solve/HomeFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 
 
@@ -21,16 +22,20 @@ class HomeFragment : Fragment(){
             val u = InnovatorApplication.getUser()
 
             val intent = Intent(getActivity(), QuestionMainActivity::class.java)
-            if(u.getGrade() == 3)
-                intent.putExtra("TOPIC",Topic.Grade3)
-            else if(u.getGrade() == 4)
-                intent.putExtra("TOPIC",Topic.Grade4)
-            else if(u.getGrade() == 5)
-                intent.putExtra("TOPIC",Topic.Grade5)
-            else if(u.getGrade() == 6)
-                intent.putExtra("TOPIC",Topic.Grade6)
-
-            startActivity(intent)
+            if (u == null) {
+                Toast.makeText(view.context, "Please Sign-in before starting questions", Toast.LENGTH_SHORT).show();
+            } else {
+                if (u.getGrade() == 3) {
+                    intent.putExtra("TOPIC", Topic.Grade3);
+                } else if (u.getGrade() == 4) {
+                    intent.putExtra("TOPIC", Topic.Grade4);
+                } else if (u.getGrade() == 5){
+                    intent.putExtra("TOPIC", Topic.Grade5);
+                }else if(u.getGrade() == 6){
+                    intent.putExtra("TOPIC", Topic.Grade6);
+                }
+                startActivity(intent)
+            }
         }
         //setContentView(view);
 

--- a/local.properties
+++ b/local.properties
@@ -4,5 +4,5 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Tue Jul 06 13:55:30 EDT 2021
-sdk.dir=C\:\\Users\\bloon.LAPTOP-E3N0EC12.000\\AppData\\Local\\Android\\Sdk
+#Fri Jul 09 10:06:01 EDT 2021
+sdk.dir=C\:\\Users\\ehu94\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
If the user has not already sign-in through their google account, a toast will pop up requiring them to do so. This ensures that the app does not crash by attempting to retrieve null data